### PR TITLE
2.0.2

### DIFF
--- a/junit.xml
+++ b/junit.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="jest tests" tests="8" failures="0" errors="0" time="1.393">
-  <testsuite name="undefined" errors="0" failures="0" skipped="0" timestamp="2023-03-07T04:07:19" time="1.286" tests="8">
-    <testcase classname=" should work" name=" should work" time="0.002">
+<testsuites name="jest tests" tests="7" failures="0" errors="0" time="2.333">
+  <testsuite name="undefined" errors="0" failures="0" skipped="0" timestamp="2023-03-22T21:48:37" time="2.225" tests="7">
+    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.021">
     </testcase>
-    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.024">
+    <testcase classname=" should retrieve by game id" name=" should retrieve by game id" time="0.025">
     </testcase>
-    <testcase classname=" should retrieve by game id" name=" should retrieve by game id" time="0.027">
-    </testcase>
-    <testcase classname=" should be searchable" name=" should be searchable" time="0.031">
+    <testcase classname=" should be searchable" name=" should be searchable" time="0.03">
     </testcase>
     <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.031">
     </testcase>
-    <testcase classname=" should be filterable for style" name=" should be filterable for style" time="0.015">
+    <testcase classname=" should be filterable for style" name=" should be filterable for style" time="0.03">
     </testcase>
-    <testcase classname=" should be filterable for nsfw" name=" should be filterable for nsfw" time="0.031">
+    <testcase classname=" should be filterable for nsfw" name=" should be filterable for nsfw" time="0.03">
     </testcase>
-    <testcase classname=" should be deletable" name=" should be deletable" time="0.031">
+    <testcase classname=" should be deletable" name=" should be deletable" time="0.03">
     </testcase>
   </testsuite>
 </testsuites>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,17 @@
             },
             "devDependencies": {
                 "@jest/globals": "^29.5.0",
-                "@types/jest": "^29.4.0",
-                "@types/node": "^18.14.6",
-                "@typescript-eslint/eslint-plugin": "^5.54.1",
-                "@typescript-eslint/parser": "^5.54.1",
-                "eslint": "^8.35.0",
+                "@types/jest": "^29.5.0",
+                "@types/node": "^18.15.5",
+                "@typescript-eslint/eslint-plugin": "^5.56.0",
+                "@typescript-eslint/parser": "^5.56.0",
+                "eslint": "^8.36.0",
                 "jest": "^29.5.0",
                 "jest-junit": "^15.0.0",
                 "nock": "^13.2.4",
                 "ts-jest": "^29.0.5",
                 "ts-loader": "^9.4.2",
-                "typescript": "^4.9.5"
+                "typescript": "^5.0.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -679,15 +679,39 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
+            "integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+            "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-            "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -703,9 +727,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-            "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1423,9 +1447,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
-            "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+            "version": "29.5.0",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+            "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -1439,9 +1463,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-            "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+            "version": "18.15.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
+            "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
             "dev": true
         },
         "node_modules/@types/prettier": {
@@ -1478,19 +1502,19 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
-            "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/type-utils": "5.54.1",
-                "@typescript-eslint/utils": "5.54.1",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/type-utils": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -1512,14 +1536,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
-            "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/typescript-estree": "5.54.1",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1539,13 +1563,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-            "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/visitor-keys": "5.54.1"
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1556,13 +1580,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
-            "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.54.1",
-                "@typescript-eslint/utils": "5.54.1",
+                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -1583,9 +1607,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-            "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1596,13 +1620,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-            "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/visitor-keys": "5.54.1",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1623,18 +1647,18 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
-            "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.54.1",
-                "@typescript-eslint/types": "5.54.1",
-                "@typescript-eslint/typescript-estree": "5.54.1",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
@@ -1649,12 +1673,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.54.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-            "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.54.1",
+                "@typescript-eslint/types": "5.56.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -2526,13 +2550,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-            "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^2.0.0",
-                "@eslint/js": "8.35.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@eslint/eslintrc": "^2.0.1",
+                "@eslint/js": "8.36.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -2543,9 +2569,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2567,7 +2592,6 @@
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
@@ -2593,33 +2617,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -2666,9 +2663,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
@@ -4779,18 +4776,6 @@
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
             "dev": true
         },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5443,16 +5428,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=12.20"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -5551,9 +5536,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.75.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "peer": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "steamgriddb",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Node.js Wrapper for the SteamGridDB API",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "files": ["dist"],
     "scripts": {
         "build": "tsc",
+        "prepack": "npm install && npm run build",
         "test": "npm run lint && jest",
         "lint": "eslint --max-warnings=0 src/** test/**"
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",
+    "files": ["dist"],
     "scripts": {
         "build": "tsc",
         "test": "npm run lint && jest",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",
-    "files": ["dist"],
+    "files": [
+        "dist"
+    ],
     "scripts": {
         "build": "tsc",
         "prepack": "npm install && npm run build",
@@ -30,16 +32,16 @@
     },
     "devDependencies": {
         "@jest/globals": "^29.5.0",
-        "@types/jest": "^29.4.0",
-        "@types/node": "^18.14.6",
-        "@typescript-eslint/eslint-plugin": "^5.54.1",
-        "@typescript-eslint/parser": "^5.54.1",
-        "eslint": "^8.35.0",
+        "@types/jest": "^29.5.0",
+        "@types/node": "^18.15.5",
+        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "@typescript-eslint/parser": "^5.56.0",
+        "eslint": "^8.36.0",
         "jest": "^29.5.0",
         "jest-junit": "^15.0.0",
         "nock": "^13.2.4",
         "ts-jest": "^29.0.5",
         "ts-loader": "^9.4.2",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.2"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ export interface SGDBImageOptions {
     mimes?: string[];
     types?: string[];
     nsfw?: string;
+    epilepsy?: string;
     humor?: string;
+    oneoftag?: string;
     page?: number;
 }
 
@@ -116,7 +118,7 @@ export default class SGDB {
             return response.data.data ?? response.data.success;
         }
 
-        const error = new axios.AxiosError("helooooo");
+        const error = new axios.AxiosError();
         error.message = response.data?.errors?.join(", ") ?? "Unknown SteamGridDB error.";
         throw error;
     }


### PR DESCRIPTION
- Added`epilepsy` and `oneoftag` to `SGDBImageOptions` interface for typescript users
- Changed package.json to ensure that project is built before publishing
- Changed package.json to only publish built files (tested with `npm pack`)
- Updated the following outdated dependencies to latest:
  - `@types/jest`
  - `@types/node`
  - `@typescript-eslint/eslint-plugin`
  - `@typescript-eslint/parser`
  - `eslint`
  - `typescript`