### PR TITLE
Fix missing type definitions

### DIFF
--- a/junit.xml
+++ b/junit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="jest tests" tests="8" failures="0" errors="0" time="1.285">
-  <testsuite name="undefined" errors="0" failures="0" skipped="0" timestamp="2024-05-30T12:57:09" time="1.147" tests="8">
-    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.022">
+<testsuites name="jest tests" tests="8" failures="0" errors="0" time="0.902">
+  <testsuite name="undefined" errors="0" failures="0" skipped="0" timestamp="2024-09-24T15:12:56" time="0.868" tests="8">
+    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.011">
     </testcase>
-    <testcase classname=" should retrieve by game id" name=" should retrieve by game id" time="0.022">
+    <testcase classname=" should retrieve by game id" name=" should retrieve by game id" time="0.003">
     </testcase>
-    <testcase classname=" should retrieve platform data" name=" should retrieve platform data" time="0.03">
+    <testcase classname=" should retrieve platform data" name=" should retrieve platform data" time="0.004">
     </testcase>
-    <testcase classname=" should be searchable" name=" should be searchable" time="0.03">
+    <testcase classname=" should be searchable" name=" should be searchable" time="0.003">
     </testcase>
-    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.03">
+    <testcase classname=" should retrieve by steam appid" name=" should retrieve by steam appid" time="0.004">
     </testcase>
-    <testcase classname=" should be filterable for style" name=" should be filterable for style" time="0.028">
+    <testcase classname=" should be filterable for style" name=" should be filterable for style" time="0.004">
     </testcase>
-    <testcase classname=" should be filterable for nsfw" name=" should be filterable for nsfw" time="0.029">
+    <testcase classname=" should be filterable for nsfw" name=" should be filterable for nsfw" time="0.003">
     </testcase>
-    <testcase classname=" should be deletable" name=" should be deletable" time="0.03">
+    <testcase classname=" should be deletable" name=" should be deletable" time="0.003">
     </testcase>
   </testsuite>
 </testsuites>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,17 @@ export interface SGDBImage {
     id: number;
     score: number;
     style: string[];
+    width: number;
+    height: number;
+    nsfw: boolean;
+    humor: boolean;
+    mime: string;    
     url: URL;
     thumb: URL;
+    lock: boolean;
+    epilepsy: boolean;
+    upvotes: number;
+    downvotes: number;
     tags: string[];
     author: SGDBAuthor;
     language: string;


### PR DESCRIPTION
The image data that I got from the `client.getGridsById(gameId)` returns the data in the format below:

```js
{
  id: 484680,
  score: 0,
  style: 'alternate',
  width: 600,
  height: 900,
  nsfw: false,
  humor: false,
  notes: null,
  mime: 'image/png',
  language: 'en',
  url: 'https://cdn2.steamgriddb.com/grid/57bc9596033a61dba1c4df9a1c728d61.png',
  thumb: 'https://cdn2.steamgriddb.com/thumb/57bc9596033a61dba1c4df9a1c728d61.jpg',
  lock: false,
  epilepsy: false,
  upvotes: 0,
  downvotes: 0,
  author: {
    name: 'ABH20',
    steam64: '76561198058544946',
    avatar: 'https://avatars.steamstatic.com/378a48fc2172839e4ca7589e1d6bb235691714fa_medium.jpg'
  }
}
```

Do I need to update those tests for the new data structure?

And are `tags` and `language` still needed? Can I remove them from the type definition?