### PR TITLE
fix: add some missing properties to `SGDBGame` and `SGDBImage`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export interface SGDBGame {
     name: string;
     types: string[];
     verified: boolean;
+    release_date: number;
 }
 
 export interface SGDBAuthor {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export interface SGDBImage {
     author: SGDBAuthor;
     language: string;
     notes: string|null;
+    width: number;
+    height: number;
+    upvotes: number;
+    downvotes: number;
 }
 
 export interface SGDBOptions {


### PR DESCRIPTION
I noticed that the `release_date` property is missing from the `SGDBGame` interface. I also noticed that `SGDBImage` was missing:
- `upvotes`
- `downvotes`
- `height`
- `width`

I assume this is a non-breaking change, and it should be pretty easy to approve.